### PR TITLE
feat(servicenow): fix set email bug in the backend

### DIFF
--- a/workspaces/servicenow/plugins/servicenow-backend/package.json
+++ b/workspaces/servicenow/plugins/servicenow-backend/package.json
@@ -35,28 +35,25 @@
   },
   "dependencies": {
     "@backstage-community/plugin-servicenow-common": "workspace:^",
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-defaults": "^0.10.0",
     "@backstage/backend-plugin-api": "^1.3.1",
-    "@backstage/catalog-client": "^1.10.0",
-    "@backstage/catalog-model": "^1.7.4",
     "@backstage/config": "^1.3.2",
     "@backstage/errors": "^1.2.7",
-    "@backstage/plugin-auth-node": "^0.6.3",
     "@backstage/plugin-catalog-node": "^1.17.0",
     "axios": "^1.9.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
-    "simple-oauth2": "^5.1.0",
-    "zod": "^3.22.4"
+    "simple-oauth2": "^5.1.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.5.0",
     "@backstage/cli": "^0.32.1",
     "@backstage/plugin-catalog-node": "^1.17.0",
     "@types/express": "^4.17.6",
+    "@types/qs": "^6",
     "@types/simple-oauth2": "^5",
     "@types/supertest": "^2.0.12",
+    "qs": "^6.14.0",
     "supertest": "^6.2.4"
   },
   "files": [

--- a/workspaces/servicenow/plugins/servicenow-backend/src/plugin.test.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/plugin.test.ts
@@ -22,12 +22,9 @@ import {
 import { startTestBackend, mockServices } from '@backstage/backend-test-utils';
 import { createRouter } from './service/router';
 import { readServiceNowConfig } from './config';
-import { CatalogClient } from '@backstage/catalog-client';
-import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 
 jest.mock('./service/router');
 jest.mock('./config');
-jest.mock('@backstage/catalog-client');
 
 describe('servicenowPlugin', () => {
   const mockRouter = jest.fn();
@@ -49,11 +46,6 @@ describe('servicenowPlugin', () => {
       mockConfig.data.servicenow,
     );
 
-    const catalogApi = catalogServiceMock();
-    (CatalogClient as jest.Mock).mockImplementation(() => {
-      return catalogApi;
-    });
-
     const httpRouter = mockServices.httpRouter.mock();
 
     await startTestBackend({
@@ -67,9 +59,6 @@ describe('servicenowPlugin', () => {
           factory: () => httpRouter,
         }),
         mockServices.httpAuth.factory(),
-        mockServices.auth.factory(),
-        mockServices.userInfo.factory(),
-        mockServices.discovery.factory(),
       ],
     });
 
@@ -77,7 +66,8 @@ describe('servicenowPlugin', () => {
     expect(createRouter).toHaveBeenCalledWith(
       expect.objectContaining({
         servicenowConfig: mockConfig.data.servicenow,
-        catalogApi: catalogApi,
+        logger: expect.anything(),
+        httpAuth: expect.anything(),
       }),
     );
     expect(httpRouter.use).toHaveBeenCalledWith(mockRouter);
@@ -99,9 +89,6 @@ describe('servicenowPlugin', () => {
           factory: () => httpRouter,
         }),
         mockServices.httpAuth.factory(),
-        mockServices.auth.factory(),
-        mockServices.userInfo.factory(),
-        mockServices.discovery.factory(),
       ],
     });
 

--- a/workspaces/servicenow/plugins/servicenow-backend/src/plugin.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/plugin.ts
@@ -19,7 +19,6 @@ import {
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './service';
 import { readServiceNowConfig } from './config';
-import { CatalogClient } from '@backstage/catalog-client';
 import { ServiceNowConfig } from '../config';
 
 /**
@@ -36,19 +35,8 @@ export const servicenowPlugin = createBackendPlugin({
         config: coreServices.rootConfig,
         httpRouter: coreServices.httpRouter,
         httpAuth: coreServices.httpAuth,
-        auth: coreServices.auth,
-        userInfoService: coreServices.userInfo,
-        discovery: coreServices.discovery,
       },
-      async init({
-        logger,
-        config,
-        httpRouter,
-        httpAuth,
-        userInfoService,
-        auth,
-        discovery,
-      }) {
+      async init({ logger, config, httpRouter, httpAuth }) {
         const servicenowConfig: ServiceNowConfig | undefined =
           readServiceNowConfig(config);
 
@@ -59,16 +47,11 @@ export const servicenowPlugin = createBackendPlugin({
           return;
         }
 
-        const catalogClient = new CatalogClient({ discoveryApi: discovery });
-
         httpRouter.use(
           await createRouter({
             logger,
             servicenowConfig,
-            userInfoService: userInfoService,
             httpAuth,
-            auth,
-            catalogApi: catalogClient,
           }),
         );
       },

--- a/workspaces/servicenow/plugins/servicenow-backend/src/service-now-rest/client.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/service-now-rest/client.ts
@@ -208,8 +208,6 @@ export class DefaultServiceNowClient implements ServiceNowClient {
     if (options.userEmail) {
       const id = await this.getUserSysIdByEmail(options.userEmail);
       queryParts.push(`caller_id=${id}^ORopened_by=${id}^ORassigned_to=${id}`);
-    } else if (options.entityId) {
-      queryParts.push(`u_backstage_entity_id=${options.entityId}`);
     }
 
     if (options.state) queryParts.push(`state${options.state}`);
@@ -220,6 +218,10 @@ export class DefaultServiceNowClient implements ServiceNowClient {
       queryParts.push(
         `short_descriptionLIKE${searchTerm}^ORdescriptionLIKE${searchTerm}`,
       );
+    }
+
+    if (options.entityId) {
+      queryParts.push(`u_backstage_entity_id=${options.entityId}`);
     }
 
     if (options.orderBy) {

--- a/workspaces/servicenow/plugins/servicenow-backend/src/service/router.test.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/service/router.test.ts
@@ -15,24 +15,17 @@
  */
 
 import {
-  AuthService,
   BackstageCredentials,
   BackstageUserPrincipal,
   HttpAuthService,
-  UserInfoService,
 } from '@backstage/backend-plugin-api';
-import { UserEntity } from '@backstage/catalog-model';
-import { NotFoundError, AuthenticationError } from '@backstage/errors';
+import { AuthenticationError } from '@backstage/errors';
 import express from 'express';
 import request from 'supertest';
 
-import { createRouter } from './router';
 import { mockErrorHandler, mockServices } from '@backstage/backend-test-utils';
-import {
-  CatalogServiceMock,
-  catalogServiceMock,
-} from '@backstage/plugin-catalog-node/testUtils';
 import { ServiceNowConfig } from '../../config';
+import { createRouter } from './router';
 
 const mockFetchIncidents = jest.fn();
 jest.mock('../service-now-rest/client', () => {
@@ -45,39 +38,24 @@ jest.mock('../service-now-rest/client', () => {
 
 describe('createRouter', () => {
   let app: express.Express;
-  let mockAuthService: jest.Mocked<AuthService>;
   let mockHttpAuthService: jest.Mocked<HttpAuthService>;
-  let mockUserInfoService: jest.Mocked<UserInfoService>;
-  let mockCatalogApi: CatalogServiceMock;
   let mockServiceNowConfig: ServiceNowConfig;
 
   beforeEach(async () => {
     jest.clearAllMocks();
 
-    mockAuthService = mockServices.auth.mock();
     mockHttpAuthService = mockServices.httpAuth.mock();
-    mockUserInfoService = mockServices.userInfo.mock();
-    mockCatalogApi = catalogServiceMock();
 
     mockServiceNowConfig = {
       servicenow: {
         instanceUrl: 'https://mock-instance.service-now.com',
-        oauth: {
-          grantType: 'client_credentials',
-          clientId: 'mock-client-id',
-          clientSecret: 'mock-client-secret',
-          tokenUrl: 'https://mock-instance.service-now.com/oauth_token.do',
-        },
       },
     };
 
     const router = await createRouter({
       logger: mockServices.logger.mock(),
       servicenowConfig: mockServiceNowConfig,
-      auth: mockAuthService,
       httpAuth: mockHttpAuthService,
-      userInfoService: mockUserInfoService,
-      catalogApi: mockCatalogApi,
     });
 
     app = express();
@@ -86,554 +64,112 @@ describe('createRouter', () => {
   });
 
   describe('GET /incidents', () => {
-    const mockBareToken = 'mock-secret-token';
-    const mockAuthHeader = `Bearer ${mockBareToken}`;
-    const mockUserEntityRef = 'user:default/test.user';
+    const mockAuthHeader = `Bearer mock-secret-token`;
     const mockCredentials: BackstageCredentials<BackstageUserPrincipal> = {
       $$type: '@backstage/BackstageCredentials',
-      principal: { type: 'user', userEntityRef: mockUserEntityRef },
+      principal: { type: 'user', userEntityRef: 'user:default/test.user' },
     };
-
-    const mockUserEmail = 'test.user@example.com';
-    const mockIncidentsData = [{ id: 'INC001', description: 'Test incident' }];
-
-    const mockUserEntity: UserEntity = {
-      apiVersion: 'backstage.io/v1alpha1',
-      kind: 'User',
-      metadata: {
-        name: 'test.user',
-        namespace: 'default',
+    const mockIncidentsData = [
+      {
+        sys_id: 'INC001',
+        number: 'INC001',
+        short_description: 'Test incident',
+        description: 'Test incident description',
+        sys_created_on: '2024-01-01',
+        priority: 1,
+        incident_state: 1,
+        url: 'https://mock-instance.service-now.com/INC001',
       },
-      spec: {
-        profile: {
-          email: mockUserEmail,
-        },
-      },
-    };
+    ];
 
-    it('should successfully retrieve incidents with query parameters', async () => {
+    it('should successfully retrieve incidents', async () => {
       mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockResolvedValue(mockUserEntity);
       mockFetchIncidents.mockResolvedValue(mockIncidentsData);
 
-      const queryParams = {
-        entityId: 'mock-entity-id',
-        limit: 10,
-        offset: 5,
-        state: 'IN1',
-        priority: 'IN1',
-        search: 'network issue',
-      };
-
       const response = await request(app)
-        .get('/incidents')
-        .query(queryParams)
+        .get('/incidents?entityId=user:default/test.user')
         .set('Authorization', mockAuthHeader);
 
       expect(response.status).toBe(200);
-      expect(response.body).toEqual(mockIncidentsData);
+      expect(response.body).toEqual(
+        expect.arrayContaining(
+          mockIncidentsData.map(_incident =>
+            expect.objectContaining({
+              sys_id: expect.any(String),
+              number: expect.any(String),
+              short_description: expect.any(String),
+              description: expect.any(String),
+              sys_created_on: expect.any(String),
+              priority: expect.any(Number),
+              incident_state: expect.any(Number),
+              url: expect.any(String),
+            }),
+          ),
+        ),
+      );
       expect(mockHttpAuthService.credentials).toHaveBeenCalledWith(
         expect.anything(),
         { allow: ['user'] },
       );
-      expect(mockUserInfoService.getUserInfo).toHaveBeenCalledWith(
-        mockCredentials,
-      );
-      expect(mockAuthService.getOwnServiceCredentials).toHaveBeenCalledTimes(1);
-      expect(mockAuthService.getPluginRequestToken).toHaveBeenCalledWith({
-        onBehalfOf: {
-          $$type: '@backstage/BackstageCredentials',
-          principal: { type: 'service', subject: 'servicenow-backend' },
-        },
-        targetPluginId: 'catalog',
+      expect(mockFetchIncidents).toHaveBeenCalledWith({
+        entityId: 'user:default/test.user',
       });
-      expect(mockCatalogApi.getEntityByRef).toHaveBeenCalledWith(
-        mockUserEntityRef,
-        { token: mockBareToken },
-      );
-      expect(mockFetchIncidents).toHaveBeenCalledWith(
-        expect.objectContaining({
-          userEmail: mockUserEmail,
-          state: queryParams.state,
-          priority: queryParams.priority,
-          search: queryParams.search,
-          limit: queryParams.limit,
-          offset: queryParams.offset,
-        }),
+    });
+
+    it('should return 400 if entityId is missing', async () => {
+      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
+
+      const response = await request(app).get('/incidents');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.message).toEqual(
+        'entityId is required if userEmail is not present.',
       );
     });
 
-    it('should return 401 if Authorization header is missing (handled by HttpAuthService mock)', async () => {
+    it('should return 401 if authorization is missing', async () => {
       mockHttpAuthService.credentials.mockRejectedValue(
         new AuthenticationError('Missing credentials'),
       );
-      const response = await request(app).get('/incidents');
+
+      const response = await request(app).get(
+        '/incidents?entityId=user:default/test.user',
+      );
+
       expect(response.status).toBe(401);
-      expect(response.body.error.name).toBe('AuthenticationError');
-      expect(response.body.error.message).toBe('Missing credentials');
       expect(mockFetchIncidents).not.toHaveBeenCalled();
     });
 
-    it('should return 401 if HttpAuthService.credentials throws AuthenticationError', async () => {
-      mockHttpAuthService.credentials.mockRejectedValue(
-        new AuthenticationError('Invalid token'),
-      );
-      const response = await request(app)
-        .get('/incidents')
-        .set('Authorization', 'Bearer invalid-token');
-      expect(response.status).toBe(401);
-      expect(response.body.error.name).toBe('AuthenticationError');
-      expect(response.body.error.message).toBe('Invalid token');
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
-    });
-
-    it('should return 500 if UserInfoService.getUserInfo fails', async () => {
+    it('should return 500 if fetching incidents fails', async () => {
       mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockRejectedValue(
-        new Error('UserInfoService internal failure'),
-      );
-      const response = await request(app)
-        .get('/incidents?entityId=mock-entity-id&state=1')
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(500);
-      expect(response.body.error.message).toBe(
-        'UserInfoService internal failure',
-      );
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
-    });
-
-    it('should return 400 if userEntityRef is missing from UserInfo', async () => {
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      // Missing userEntityRef
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        ownershipEntityRefs: [],
-      } as any);
-      const response = await request(app)
-        .get('/incidents?entityId=mock-entity-for-failure-test')
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(400);
-      expect(response.body.error.name).toBe('InputError');
-      expect(response.body.error.message).toContain(
-        'User entity reference not found in user info',
-      );
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
-    });
-
-    it('should return 401 if AuthService.getPluginRequestToken fails (e.g. returns undefined token)', async () => {
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      // Simulate missing plugin token
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: undefined,
-      } as any);
-      const response = await request(app)
-        .get('/incidents?entityId=mock-entity-for-failure-test')
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(401); // Or appropriate error based on router logic
-      expect(response.body.error.name).toBe('AuthenticationError');
-      expect(response.body.error.message).toContain(
-        'Plugin token is missing or invalid',
-      );
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
-    });
-
-    it('should return 404 if CatalogApi.getEntityByRef returns undefined', async () => {
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest.fn().mockResolvedValue(undefined);
-      const response = await request(app)
-        .get('/incidents?entityId=mock-entity-for-failure-test')
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(404);
-      expect(response.body.error.name).toBe('NotFoundError');
-      expect(response.body.error.message).toContain(
-        `User entity not found for ref: ${mockUserEntityRef}`,
-      );
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
-    });
-
-    it('should return 404 if CatalogApi.getEntityByRef throws NotFoundError', async () => {
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockRejectedValue(
-          new NotFoundError('Catalog entity explicitly not found'),
-        );
-      const response = await request(app)
-        .get('/incidents?entityId=mock-entity-for-failure-test')
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(404);
-      expect(response.body.error.name).toBe('NotFoundError');
-      expect(response.body.error.message).toBe(
-        'Catalog entity explicitly not found',
-      );
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
-    });
-
-    it('should return 500 if CatalogApi.getEntityByRef fails with a generic error', async () => {
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockRejectedValue(new Error('CatalogApi generic failure'));
-      const response = await request(app)
-        .get('/incidents')
-        .query({ entityId: 'mock-entity-for-test' })
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(500);
-      expect(response.body.error.message).toBe('CatalogApi generic failure');
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
-    });
-
-    it('should return 404 if user entity lacks spec.profile.email', async () => {
-      const userEntityWithoutEmail: UserEntity = {
-        apiVersion: 'backstage.io/v1alpha1',
-        kind: 'User',
-        metadata: { name: 'test.user', namespace: 'default' },
-        spec: { profile: {} },
-      };
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockResolvedValue(userEntityWithoutEmail);
-      const response = await request(app)
-        .get('/incidents')
-        .query({ entityId: 'mock-entity-for-test' })
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(404);
-      expect(response.body.error.name).toBe('NotFoundError');
-      expect(response.body.error.message).toContain(
-        `Email not found for user ${mockUserEntityRef}`,
-      );
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
-    });
-
-    it('should return 404 if user entity has undefined email', async () => {
-      const userEntityWithUndefinedEmail: UserEntity = {
-        apiVersion: 'backstage.io/v1alpha1',
-        kind: 'User',
-        metadata: { name: 'test.user', namespace: 'default' },
-        spec: { profile: { email: undefined } },
-      };
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockResolvedValue(userEntityWithUndefinedEmail);
-      const response = await request(app)
-        .get('/incidents')
-        .query({ entityId: 'mock-entity-for-test' })
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(404);
-      expect(response.body.error.name).toBe('NotFoundError');
-      expect(response.body.error.message).toContain(
-        `Email not found for user ${mockUserEntityRef}`,
-      );
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
-    });
-
-    it('should return 404 if user entity from catalog lacks spec.profile (thus no email)', async () => {
-      const userEntityWithoutProfile: UserEntity = {
-        apiVersion: 'backstage.io/v1alpha1',
-        kind: 'User',
-        metadata: { name: 'test.user', namespace: 'default' },
-        spec: {
-          memberOf: [],
-        },
-      };
-
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockResolvedValue(userEntityWithoutProfile);
+      mockFetchIncidents.mockRejectedValue(new Error('ServiceNow is down'));
 
       const response = await request(app)
-        .get('/incidents')
-        .query({ entityId: 'mock-entity-for-test' })
+        .get('/incidents?entityId=user:default/test.user')
         .set('Authorization', mockAuthHeader);
 
-      expect(response.status).toBe(404);
-      expect(response.body.error.name).toBe('NotFoundError');
-      expect(response.body.error.message).toContain(
-        `Email not found for user ${mockUserEntityRef}`,
-      );
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
-    });
-
-    it('should return 500 if ServiceNowClient.fetchIncidents fails', async () => {
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockResolvedValue(mockUserEntity);
-      mockFetchIncidents.mockRejectedValue(
-        new Error('ServiceNow client fetch failure'),
-      );
-      const response = await request(app)
-        .get('/incidents')
-        .query({ entityId: 'mock-entity-for-test' })
-        .set('Authorization', mockAuthHeader);
       expect(response.status).toBe(500);
       expect(response.body.error.message).toBe(
         'Failed to fetch incidents from ServiceNow',
       );
     });
 
-    it('should return 400 for invalid limit parameter (e.g., "abc")', async () => {
+    it('should successfully retrieve incidents when both userEmail and entityId are provided', async () => {
       mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockResolvedValue(mockUserEntity);
-      const response = await request(app)
-        .get('/incidents?entityId=mock-entity-id&limit=abc')
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(400);
-      expect(response.body.error.name).toBe('InputError');
-      expect(response.body.error.message).toBe(
-        'limit must be a non-negative integer.',
-      );
-    });
-
-    it('should return 400 for negative limit parameter (e.g., -1)', async () => {
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockResolvedValue(mockUserEntity);
-      const response = await request(app)
-        .get('/incidents?entityId=mock-entity-id&limit=-1')
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(400);
-      expect(response.body.error.name).toBe('InputError');
-      expect(response.body.error.message).toBe(
-        'limit must be a non-negative integer.',
-      );
-    });
-
-    it('should return 400 for invalid offset parameter (e.g., "xyz")', async () => {
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockResolvedValue(mockUserEntity);
-      const response = await request(app)
-        .get('/incidents?entityId=mock-entity-id&offset=xyz')
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(400);
-      expect(response.body.error.name).toBe('InputError');
-      expect(response.body.error.message).toBe(
-        'offset must be a non-negative integer.',
-      );
-    });
-
-    it('should return 400 for negative offset parameter (e.g., -5)', async () => {
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockResolvedValue(mockUserEntity);
-      const response = await request(app)
-        .get('/incidents?entityId=mock-entity-id&offset=-5')
-        .set('Authorization', mockAuthHeader);
-      expect(response.status).toBe(400);
-      expect(response.body.error.name).toBe('InputError');
-      expect(response.body.error.message).toBe(
-        'offset must be a non-negative integer.',
-      );
-    });
-
-    it('should return 400 if state parameter does not use IN prefix', async () => {
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
-      });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockResolvedValue(mockUserEntity);
+      mockFetchIncidents.mockResolvedValue(mockIncidentsData);
 
       const response = await request(app)
-        .get('/incidents')
-        .query({ entityId: 'mock-entity-id', state: '1' })
+        .get(
+          '/incidents?userEmail=test.user@example.com&entityId=user:default/test.user',
+        )
         .set('Authorization', mockAuthHeader);
 
-      expect(response.status).toBe(400);
-      expect(response.body.error.name).toBe('InputError');
-      expect(response.body.error.message).toBe(
-        "Query parameter 'state' must use the 'IN' prefix format (e.g., 'INvalue1,value2' or 'INvalue').",
-      );
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
-    });
-
-    it('should return 400 if priority parameter does not use IN prefix', async () => {
-      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
-      mockUserInfoService.getUserInfo.mockResolvedValue({
-        userEntityRef: mockUserEntityRef,
-        ownershipEntityRefs: [],
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(mockIncidentsData);
+      expect(mockFetchIncidents).toHaveBeenCalledWith({
+        userEmail: 'test.user@example.com',
+        entityId: 'user:default/test.user',
       });
-      mockAuthService.getOwnServiceCredentials.mockResolvedValue({
-        $$type: '@backstage/BackstageCredentials',
-        principal: { type: 'service', subject: 'servicenow-backend' },
-      });
-      mockAuthService.getPluginRequestToken.mockResolvedValue({
-        token: mockBareToken,
-      });
-      mockCatalogApi.getEntityByRef = jest
-        .fn()
-        .mockResolvedValue(mockUserEntity);
-
-      const response = await request(app)
-        .get('/incidents')
-        .query({ entityId: 'mock-entity-id', priority: '1' })
-        .set('Authorization', mockAuthHeader);
-
-      expect(response.status).toBe(400);
-      expect(response.body.error.name).toBe('InputError');
-      expect(response.body.error.message).toBe(
-        "Query parameter 'priority' must use the 'IN' prefix format (e.g., 'INvalue1,value2' or 'INvalue').",
-      );
-      expect(mockFetchIncidents).not.toHaveBeenCalled();
     });
   });
 });

--- a/workspaces/servicenow/plugins/servicenow-backend/src/service/validator.test.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/service/validator.test.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InputError } from '@backstage/errors';
+import { validateIncidentQueryParams } from './validator';
+import { ParsedQs } from 'qs';
+
+describe('validateIncidentQueryParams', () => {
+  it('should validate with userEmail only', () => {
+    const query = { userEmail: 'test@example.com' } as ParsedQs;
+    expect(validateIncidentQueryParams(query)).toEqual({
+      userEmail: 'test@example.com',
+    });
+  });
+
+  it('should validate with entityId only', () => {
+    const query = { entityId: '123' } as ParsedQs;
+    expect(validateIncidentQueryParams(query)).toEqual({ entityId: '123' });
+  });
+
+  it('should throw InputError when neither userEmail nor entityId is provided', () => {
+    const query = {} as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError('entityId is required if userEmail is not present.'),
+    );
+  });
+
+  it('should allow both userEmail and entityId', () => {
+    const query = {
+      userEmail: 'test@example.com',
+      entityId: '123',
+    } as ParsedQs;
+    const result = validateIncidentQueryParams(query);
+    expect(result).toEqual({
+      userEmail: 'test@example.com',
+      entityId: '123',
+    });
+  });
+
+  it('should throw InputError for invalid userEmail format', () => {
+    const query = { userEmail: 'invalid-email' } as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError('userEmail must be a valid email address.'),
+    );
+  });
+
+  it('should validate limit correctly', () => {
+    const query = { entityId: '123', limit: '10' } as ParsedQs;
+    expect(validateIncidentQueryParams(query)).toEqual({
+      entityId: '123',
+      limit: 10,
+    });
+  });
+
+  it('should throw InputError for invalid limit', () => {
+    const query = { entityId: '123', limit: 'abc' } as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError('limit must be a non-negative integer.'),
+    );
+
+    const query2 = { entityId: '123', limit: '-10' } as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError('limit must be a non-negative integer.'),
+    );
+    expect(() => validateIncidentQueryParams(query2)).toThrow(
+      new InputError('limit must be a non-negative integer.'),
+    );
+  });
+
+  it('should validate offset correctly', () => {
+    const query = { entityId: '123', offset: '5' } as ParsedQs;
+    expect(validateIncidentQueryParams(query)).toEqual({
+      entityId: '123',
+      offset: 5,
+    });
+  });
+
+  it('should throw InputError for invalid offset', () => {
+    const query = { entityId: '123', offset: 'xyz' } as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError('offset must be a non-negative integer.'),
+    );
+
+    const query2 = { entityId: '123', offset: '-5' } as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError('offset must be a non-negative integer.'),
+    );
+    expect(() => validateIncidentQueryParams(query2)).toThrow(
+      new InputError('offset must be a non-negative integer.'),
+    );
+  });
+
+  it('should validate order correctly', () => {
+    const query = { entityId: '123', order: 'asc' } as ParsedQs;
+    expect(validateIncidentQueryParams(query)).toEqual({
+      entityId: '123',
+      order: 'asc',
+    });
+
+    const query2 = { entityId: '123', order: 'desc' } as ParsedQs;
+    expect(validateIncidentQueryParams(query2)).toEqual({
+      entityId: '123',
+      order: 'desc',
+    });
+  });
+
+  it('should throw InputError for invalid order', () => {
+    const query = { entityId: '123', order: 'invalid' } as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError("order must be 'asc' or 'desc'."),
+    );
+  });
+
+  it('should validate orderBy correctly', () => {
+    const query = { entityId: '123', orderBy: 'number' } as ParsedQs;
+    expect(validateIncidentQueryParams(query)).toEqual({
+      entityId: '123',
+      orderBy: 'number',
+    });
+  });
+
+  it('should throw InputError for invalid orderBy', () => {
+    const query = { entityId: '123', orderBy: 'invalid' } as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError(
+        'Invalid orderBy field. Allowed values are: number, short_description, description, sys_created_on, priority, incident_state, url',
+      ),
+    );
+  });
+
+  it('should validate state correctly', () => {
+    const query = { entityId: '123', state: 'IN1,2,3' } as ParsedQs;
+    expect(validateIncidentQueryParams(query)).toEqual({
+      entityId: '123',
+      state: 'IN1,2,3',
+    });
+  });
+
+  it('should throw InputError for invalid state', () => {
+    const query = { entityId: '123', state: 'invalid' } as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError(
+        "Query parameter 'state' must use the 'IN' prefix format (e.g., 'INvalue1,value2' or 'INvalue').",
+      ),
+    );
+
+    const query2 = { entityId: '123', state: 'IN1,2,invalid' } as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError(
+        "Query parameter 'state' must use the 'IN' prefix format (e.g., 'INvalue1,value2' or 'INvalue').",
+      ),
+    );
+    expect(() => validateIncidentQueryParams(query2)).toThrow(
+      new InputError(
+        "Invalid value 'invalid' for query parameter 'state' in 'IN' list 'IN1,2,invalid'. Allowed values are: 1, 2, 3, 6, 7, 8.",
+      ),
+    );
+  });
+
+  it('should validate priority correctly', () => {
+    const query = { entityId: '123', priority: 'IN1,2,3' } as ParsedQs;
+    expect(validateIncidentQueryParams(query)).toEqual({
+      entityId: '123',
+      priority: 'IN1,2,3',
+    });
+  });
+
+  it('should throw InputError for invalid priority', () => {
+    const query = { entityId: '123', priority: 'invalid' } as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError(
+        "Query parameter 'priority' must use the 'IN' prefix format (e.g., 'INvalue1,value2' or 'INvalue').",
+      ),
+    );
+
+    const query2 = { entityId: '123', priority: 'IN1,2,invalid' } as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError(
+        "Query parameter 'priority' must use the 'IN' prefix format (e.g., 'INvalue1,value2' or 'INvalue').",
+      ),
+    );
+    expect(() => validateIncidentQueryParams(query2)).toThrow(
+      new InputError(
+        "Invalid value 'invalid' for query parameter 'priority' in 'IN' list 'IN1,2,invalid'. Allowed values are: 1, 2, 3, 4, 5.",
+      ),
+    );
+  });
+
+  it('should validate search correctly', () => {
+    const query = { entityId: '123', search: 'test search' } as ParsedQs;
+    expect(validateIncidentQueryParams(query)).toEqual({
+      entityId: '123',
+      search: 'test search',
+    });
+  });
+
+  it('should throw InputError for invalid search', () => {
+    const query = { entityId: '123', search: 123 } as unknown as ParsedQs;
+    expect(() => validateIncidentQueryParams(query)).toThrow(
+      new InputError('search must be a string.'),
+    );
+  });
+});

--- a/workspaces/servicenow/plugins/servicenow-backend/src/service/validator.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/service/validator.ts
@@ -84,7 +84,6 @@ function parseAndValidateMultiValueQueryParam(
 
 export function validateIncidentQueryParams(
   query: ParsedQs,
-  userEmail: string,
 ): IncidentQueryParams {
   const {
     entityId: entityIdQuery,
@@ -95,40 +94,32 @@ export function validateIncidentQueryParams(
     offset: offsetQuery,
     order: orderQuery,
     orderBy: orderByQuery,
+    userEmail: userEmailQuery,
   } = query;
-
-  let entityId: string | undefined;
-
-  if (userEmail === undefined) {
-    // entityId is required if userEmail is not present
-    if (typeof entityIdQuery !== 'string' || !entityIdQuery.trim()) {
-      throw new InputError(
-        'Either userEmail or entityId must be provided. entityId is missing.',
-      );
-    }
-    entityId = entityIdQuery.trim();
-  } else {
-    // userEmail is present, entityId is optional
-    if (typeof entityIdQuery === 'string' && entityIdQuery.trim()) {
-      entityId = entityIdQuery.trim();
-    }
-  }
+  const validatedParams: IncidentQueryParams = {};
 
   // userEmail validation
-  if (userEmail !== undefined) {
-    if (typeof userEmail !== 'string' || !userEmail.trim()) {
+  if (userEmailQuery !== undefined) {
+    if (typeof userEmailQuery !== 'string' || !userEmailQuery.trim()) {
       throw new InputError('userEmail must be a non-empty string.');
     }
     // Basic email format validation
-    if (!/.+@.+\..+/.test(userEmail)) {
+    if (!/.+@.+\..+/.test(userEmailQuery)) {
       throw new InputError('userEmail must be a valid email address.');
     }
+    validatedParams.userEmail = userEmailQuery.trim();
   }
 
-  const validatedParams: IncidentQueryParams = {
-    entityId,
-    userEmail,
-  };
+  if (entityIdQuery !== undefined) {
+    if (typeof entityIdQuery !== 'string' || !entityIdQuery.trim()) {
+      throw new InputError('entityId must be a non-empty string.');
+    }
+    validatedParams.entityId = entityIdQuery.trim();
+  }
+
+  if (!validatedParams.userEmail && !validatedParams.entityId) {
+    throw new InputError('entityId is required if userEmail is not present.');
+  }
 
   // limit validation
   if (limitQuery !== undefined) {

--- a/workspaces/servicenow/plugins/servicenow/package.json
+++ b/workspaces/servicenow/plugins/servicenow/package.json
@@ -58,11 +58,13 @@
     "@backstage/core-app-api": "^1.17.0",
     "@backstage/dev-utils": "^1.1.10",
     "@backstage/test-utils": "^1.7.8",
+    "@material-ui/core": "^4.12.4",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
     "msw": "^1.0.0",
-    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "rxjs": "^7.8.2"
   },
   "files": [
     "dist"

--- a/workspaces/servicenow/plugins/servicenow/src/components/Servicenow/ServicenowContent.test.tsx
+++ b/workspaces/servicenow/plugins/servicenow/src/components/Servicenow/ServicenowContent.test.tsx
@@ -15,14 +15,22 @@
  */
 
 import { EntityProvider, catalogApiRef } from '@backstage/plugin-catalog-react';
-import { screen, waitFor } from '@testing-library/react';
-import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/test-utils';
 import { ServiceAnnotationFieldName } from '@backstage-community/plugin-servicenow-common';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider, createTheme } from '@material-ui/core';
 import { serviceNowApiRef } from '../../api/ServiceNowBackendClient';
 import { mockIncidents } from '../../mocks/mockData';
 import userEvent from '@testing-library/user-event';
 import { ServicenowContent } from './ServicenowContent';
-import { identityApiRef } from '@backstage/core-plugin-api';
+import {
+  identityApiRef,
+  alertApiRef,
+  errorApiRef,
+} from '@backstage/core-plugin-api';
+import { translationApiRef } from '@backstage/core-plugin-api/alpha';
+import { of } from 'rxjs';
 
 const mockEntity = {
   apiVersion: 'backstage.io/v1alpha1',
@@ -49,27 +57,30 @@ const mockIdentityApi = {
   signOut: async () => {},
 };
 
-jest.mock('react-router-dom', () => {
-  const originalModule = jest.requireActual('react-router-dom');
-  return {
-    ...originalModule,
-    useSearchParams: () => {
-      const params = new URLSearchParams();
-      const setSearchParams = jest.fn();
-      return [params, setSearchParams];
-    },
-  };
-});
+const mockAlertApi = {
+  post: jest.fn(),
+  alert$: jest.fn(),
+};
 
-jest.mock('../../hooks/useDebouncedValue', () => ({
-  useDebouncedValue: (value: string) => value,
-}));
+const mockErrorApi = {
+  post: jest.fn(),
+  error$: jest.fn(),
+};
 
-jest.mock('../../hooks/useQueryState', () => ({
-  useQueryState: (_: string, defaultValue: any) => {
-    return [defaultValue, jest.fn()];
-  },
-}));
+const mockTranslationApi = {
+  getTranslation: jest.fn().mockReturnValue({
+    ready: true,
+    t: (key: string) => key,
+  }),
+  translation$: jest.fn().mockReturnValue(
+    of({
+      ready: true,
+      t: (key: string) => key,
+    }),
+  ),
+};
+
+const theme = createTheme();
 
 describe('ServicenowContent', () => {
   const mockServiceNowApi = {
@@ -82,18 +93,25 @@ describe('ServicenowContent', () => {
   });
 
   it('renders the table with incident rows', async () => {
-    await renderInTestApp(
-      <TestApiProvider
-        apis={[
-          [serviceNowApiRef, mockServiceNowApi],
-          [catalogApiRef, mockCatalogApi],
-          [identityApiRef, mockIdentityApi],
-        ]}
-      >
-        <EntityProvider entity={mockEntity}>
-          <ServicenowContent />
-        </EntityProvider>
-      </TestApiProvider>,
+    render(
+      <MemoryRouter>
+        <ThemeProvider theme={theme}>
+          <TestApiProvider
+            apis={[
+              [serviceNowApiRef, mockServiceNowApi],
+              [catalogApiRef, mockCatalogApi],
+              [identityApiRef, mockIdentityApi],
+              [alertApiRef, mockAlertApi],
+              [errorApiRef, mockErrorApi],
+              [translationApiRef, mockTranslationApi as any],
+            ]}
+          >
+            <EntityProvider entity={mockEntity}>
+              <ServicenowContent />
+            </EntityProvider>
+          </TestApiProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
     );
 
     await waitFor(() => {
@@ -117,18 +135,25 @@ describe('ServicenowContent', () => {
   });
 
   it('displays pagination dropdown', async () => {
-    await renderInTestApp(
-      <TestApiProvider
-        apis={[
-          [serviceNowApiRef, mockServiceNowApi],
-          [catalogApiRef, mockCatalogApi],
-          [identityApiRef, mockIdentityApi],
-        ]}
-      >
-        <EntityProvider entity={mockEntity}>
-          <ServicenowContent />
-        </EntityProvider>
-      </TestApiProvider>,
+    render(
+      <MemoryRouter>
+        <ThemeProvider theme={theme}>
+          <TestApiProvider
+            apis={[
+              [serviceNowApiRef, mockServiceNowApi],
+              [catalogApiRef, mockCatalogApi],
+              [identityApiRef, mockIdentityApi],
+              [alertApiRef, mockAlertApi],
+              [errorApiRef, mockErrorApi],
+              [translationApiRef, mockTranslationApi as any],
+            ]}
+          >
+            <EntityProvider entity={mockEntity}>
+              <ServicenowContent />
+            </EntityProvider>
+          </TestApiProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
     );
 
     await waitFor(() => {
@@ -147,18 +172,25 @@ describe('ServicenowContent', () => {
   it('shows empty content placeholder when no incidents are available', async () => {
     mockServiceNowApi.getIncidents.mockResolvedValue([]);
 
-    await renderInTestApp(
-      <TestApiProvider
-        apis={[
-          [serviceNowApiRef, mockServiceNowApi],
-          [catalogApiRef, mockCatalogApi],
-          [identityApiRef, mockIdentityApi],
-        ]}
-      >
-        <EntityProvider entity={mockEntity}>
-          <ServicenowContent />
-        </EntityProvider>
-      </TestApiProvider>,
+    render(
+      <MemoryRouter>
+        <ThemeProvider theme={theme}>
+          <TestApiProvider
+            apis={[
+              [serviceNowApiRef, mockServiceNowApi],
+              [catalogApiRef, mockCatalogApi],
+              [identityApiRef, mockIdentityApi],
+              [alertApiRef, mockAlertApi],
+              [errorApiRef, mockErrorApi],
+              [translationApiRef, mockTranslationApi as any],
+            ]}
+          >
+            <EntityProvider entity={mockEntity}>
+              <ServicenowContent />
+            </EntityProvider>
+          </TestApiProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
     );
 
     await waitFor(() => {
@@ -173,18 +205,25 @@ describe('ServicenowContent', () => {
 
   it('handles search input updates', async () => {
     const user = userEvent.setup();
-    await renderInTestApp(
-      <TestApiProvider
-        apis={[
-          [serviceNowApiRef, mockServiceNowApi],
-          [catalogApiRef, mockCatalogApi],
-          [identityApiRef, mockIdentityApi],
-        ]}
-      >
-        <EntityProvider entity={mockEntity}>
-          <ServicenowContent />
-        </EntityProvider>
-      </TestApiProvider>,
+    render(
+      <MemoryRouter>
+        <ThemeProvider theme={theme}>
+          <TestApiProvider
+            apis={[
+              [serviceNowApiRef, mockServiceNowApi],
+              [catalogApiRef, mockCatalogApi],
+              [identityApiRef, mockIdentityApi],
+              [alertApiRef, mockAlertApi],
+              [errorApiRef, mockErrorApi],
+              [translationApiRef, mockTranslationApi as any],
+            ]}
+          >
+            <EntityProvider entity={mockEntity}>
+              <ServicenowContent />
+            </EntityProvider>
+          </TestApiProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
     );
 
     await waitFor(() => {

--- a/workspaces/servicenow/plugins/servicenow/src/components/Servicenow/ServicenowContent.tsx
+++ b/workspaces/servicenow/plugins/servicenow/src/components/Servicenow/ServicenowContent.tsx
@@ -79,7 +79,9 @@ export const ServicenowContent = () => {
   const entityId = entity.metadata.annotations?.[ServiceAnnotationFieldName];
   const priorityFromParams = searchParams.get('priority');
   const stateFromParams = searchParams.get('state');
-  const userEmail = useUserEmail();
+
+  const kind = entity.kind.toLocaleLowerCase('en-US');
+  const userEmail = useUserEmail(kind);
 
   useEffect(() => {
     setSearchParams(
@@ -134,8 +136,8 @@ export const ServicenowContent = () => {
           search: debouncedSearch,
           priority: priorityFromParams?.split(',') ?? undefined,
           state: stateFromParams?.split(',') ?? undefined,
-          ...(userEmail ? { userEmail } : {}),
-          ...(entityId && !userEmail ? { entityId } : {}),
+          userEmail,
+          entityId,
         });
 
         const data = await serviceNowApi.getIncidents(queryParams);

--- a/workspaces/servicenow/yarn.lock
+++ b/workspaces/servicenow/yarn.lock
@@ -2756,26 +2756,23 @@ __metadata:
   resolution: "@backstage-community/plugin-servicenow-backend@workspace:plugins/servicenow-backend"
   dependencies:
     "@backstage-community/plugin-servicenow-common": "workspace:^"
-    "@backstage/backend-common": "npm:^0.25.0"
     "@backstage/backend-defaults": "npm:^0.10.0"
     "@backstage/backend-plugin-api": "npm:^1.3.1"
     "@backstage/backend-test-utils": "npm:^1.5.0"
-    "@backstage/catalog-client": "npm:^1.10.0"
-    "@backstage/catalog-model": "npm:^1.7.4"
     "@backstage/cli": "npm:^0.32.1"
     "@backstage/config": "npm:^1.3.2"
     "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-auth-node": "npm:^0.6.3"
     "@backstage/plugin-catalog-node": "npm:^1.17.0"
     "@types/express": "npm:^4.17.6"
+    "@types/qs": "npm:^6"
     "@types/simple-oauth2": "npm:^5"
     "@types/supertest": "npm:^2.0.12"
     axios: "npm:^1.9.0"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
+    qs: "npm:^6.14.0"
     simple-oauth2: "npm:^5.1.0"
     supertest: "npm:^6.2.4"
-    zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
 
@@ -2802,6 +2799,7 @@ __metadata:
     "@backstage/plugin-user-settings": "npm:^0.8.23"
     "@backstage/test-utils": "npm:^1.7.8"
     "@backstage/theme": "npm:^0.6.6"
+    "@material-ui/core": "npm:^4.12.4"
     "@mui/icons-material": "npm:^5.15.17"
     "@mui/lab": "npm:^5.0.0-alpha.153"
     "@mui/material": "npm:^5.17.1"
@@ -2812,6 +2810,7 @@ __metadata:
     msw: "npm:^1.0.0"
     react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
     react-use: "npm:^17.2.4"
+    rxjs: "npm:^7.8.2"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -13544,7 +13543,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/qs@npm:*, @types/qs@npm:^6.9.6":
+"@types/qs@npm:*, @types/qs@npm:^6, @types/qs@npm:^6.9.6":
   version: 6.14.0
   resolution: "@types/qs@npm:6.14.0"
   checksum: 10/1909205514d22b3cbc7c2314e2bd8056d5f05dfb21cf4377f0730ee5e338ea19957c41735d5e4806c746176563f50005bbab602d8358432e25d900bdf4970826
@@ -30260,7 +30259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:7.8.2, rxjs@npm:^7.5.5":
+"rxjs@npm:7.8.2, rxjs@npm:^7.5.5, rxjs@npm:^7.8.2":
   version: 7.8.2
   resolution: "rxjs@npm:7.8.2"
   dependencies:


### PR DESCRIPTION
Fix set email bug in the backend. Allow both email and entityId query params at the same time. Don't fetch user email in the backend, since we can get this information from the frontent. Simplify backend and frontend code. Move validator test caces to the separated file. Avoid hack with profile path param.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
